### PR TITLE
A114 - moved some urls into /api/v1, added json get, altered container info

### DIFF
--- a/app/controllers/work_orders_controller.rb
+++ b/app/controllers/work_orders_controller.rb
@@ -10,11 +10,10 @@ class WorkOrdersController < ApplicationController
 
   before_action :work_order, only: [:show, :complete, :cancel]
 
-
   # In the request from the LIMS to complete or cancel a work order, there is no
   # authenticated user in the request so we skip the authentication step
-  skip_authenticate_user :only => [:complete, :cancel]
-  skip_authorization_check :only => [:index, :complete, :cancel]
+  skip_authenticate_user :only => [:complete, :cancel, :get]
+  skip_authorization_check :only => [:index, :complete, :cancel, :get]
 
   def index
     if user_signed_in?
@@ -57,6 +56,14 @@ class WorkOrdersController < ApplicationController
     authorize! :read, work_order
   end
 
+  # -------- API ---------
+
+  def get
+    render json: work_order.lims_data, status: 200
+  rescue ActiveRecord::RecordNotFound
+    render json: {errors: [{status: '404', detail: 'Record not found'}]}, status: 404
+  end
+
   def complete
     finish('complete')
   end
@@ -74,7 +81,7 @@ class WorkOrdersController < ApplicationController
     else
       result = validator.errors
     end
-    render json: { message: result[:msg] }, :status => result[:status]
+    render json: { message: result[:msg] }, status: result[:status]
   end
 
 private

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -167,9 +167,9 @@ class WorkOrder < ApplicationRecord
           if material_ids.include? slot.material_id
             unless material_map[slot.material_id][:container]
               container_data = { barcode: container.barcode }
-              if (container.num_of_rows > 1 || container.num_of_cols > 1)
-                container_data[:address] = slot.address
-              end
+              container_data[:num_of_rows] = container.num_of_rows
+              container_data[:num_of_cols] = container.num_of_cols
+              container_data[:address] = slot.address
               material_map[slot.material_id][:container] = container_data
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,15 +4,17 @@ Rails.application.routes.draw do
   mount Rswag::Api::Engine => '/api-docs'
   root 'work_orders#index'
 
-  resources :catalogues
-  post '/catalogue', to: 'catalogues#create'
+  scope '/api/v1' do
+    post 'catalogue', to: 'catalogues#create'
+    scope 'work_orders/:id' do
+      post 'complete', to: 'work_orders#complete'
+      post 'cancel', to: 'work_orders#cancel'
+      get '', to: 'work_orders#get'
+    end
+  end
 
   resources :work_orders do
   	resources :build, controller: 'orders'
-  	member do
-	    post 'complete', to: 'work_orders#complete'
-	    post 'cancel', to: 'work_orders#cancel'
-  	end
   end
 
 end

--- a/features/create_order.feature
+++ b/features/create_order.feature
@@ -16,6 +16,8 @@ And the following sets are defined for user "test@test":
 | testing_set_1 | 3    |
 | testing_set_2 | 5    |
 
+And my set contents materials are all available
+
 Given a LIMS named "flimsy" at url "http://flimsy" has the following catalogue ready for send:
 
 | Name           | Description | Version | Available? | Material Type | TAT | Product Class      |
@@ -35,6 +37,7 @@ Then I should have received the catalogue from the LIMS "flimsy" correctly
 Scenario: Creating a work order
 
 Given I already received the catalogue from LIMS "flimsy"
+
 When I go to the work order main page
 And I click on "Create New Work Order"
 

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -149,7 +149,7 @@ Given(/^a LIMS named "([^"]*)" at url "([^"]*)" has the following catalogue read
 end
 
 When(/^the LIMS "([^"]*)" send me the catalogue$/) do |lims_name|
-  post catalogues_path, @catalogues[lims_name]
+  post catalogue_path, @catalogues[lims_name]
 end
 
 Then(/^I should have received the catalogue from the LIMS "([^"]*)" correctly/) do |lims_name|
@@ -202,6 +202,10 @@ Given(/^I process the work order "([^"]*)" with the LIMS/) do |arg1|
   @work_order.update_attributes(status: WorkOrder.ACTIVE)
 end
 
+Given(/^my set contents materials are all available$/) do 
+  allow_any_instance_of(UpdateOrderService).to receive(:check_set_contents).and_return(true)
+end
+
 When(/^I send a completion message from the LIMS to the work order application$/) do
   step('I prepare for a finish message')
 
@@ -211,7 +215,7 @@ When(/^I send a completion message from the LIMS to the work order application$/
   header "HTTP_ACCEPT", "application/json"
   header "CONTENT_TYPE", "application/json"
 
-  post complete_work_order_path(@work_order), @work_order_completion_msg.to_json
+  post complete_path(@work_order), @work_order_completion_msg.to_json
 end
 
 When(/^I send a cancel message from the LIMS to the work order application$/) do
@@ -223,7 +227,7 @@ When(/^I send a cancel message from the LIMS to the work order application$/) do
   header "HTTP_ACCEPT", "application/json"
   header "CONTENT_TYPE", "application/json"
 
-  post cancel_work_order_path(@work_order), @work_order_completion_msg.to_json
+  post cancel_path(@work_order), @work_order_completion_msg.to_json
 end
 
 When(/^I prepare for a finish message$/) do

--- a/spec/controllers/work_orders_controller_spec.rb
+++ b/spec/controllers/work_orders_controller_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe WorkOrdersController, type: :controller do
     end
   end
 
+  describe "#get" do
+    context 'when the work order exists' do
+      it 'renders the work order json' do
+        user = create(:user, email: 'jeff@sanger.ac.uk')
+        wo = WorkOrder.create(user_id: user.id, status: WorkOrder.ACTIVE)
+        data = {alpha: :beta}
+        expect_any_instance_of(WorkOrder).to receive(:lims_data).and_return(data)
+        get :get, params: { id: wo.id }
+        expect(response).to have_http_status(:ok)
+        expect(response.redirect_url).to be_nil
+        expect(response.body).to eq(data.to_json)
+      end
+    end
+    context 'when the work order does not exist' do
+      it 'returns 404' do
+        get :get, params: { id: 0 }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "#destroy" do
     context "when the work order is destructible" do
       before do

--- a/spec/integration/work_orders_spec.rb
+++ b/spec/integration/work_orders_spec.rb
@@ -28,8 +28,7 @@ describe 'Work Orders API' do
   }
 
 
-  path '/work_orders/{work_order_id}/complete' do
-
+  path '/api/v1/work_orders/{work_order_id}/complete' do
 
     post 'Completes a work order' do
       tags 'Work Orders'
@@ -57,7 +56,7 @@ describe 'Work Orders API' do
     end
   end
 
-  path '/work_orders/{work_order_id}/cancel' do
+  path '/api/v1/work_orders/{work_order_id}/cancel' do
 
     post 'Cancels a work order' do
       tags 'Work Orders'

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe WorkOrder, type: :model do
         @materials.zip(material_data).each do |mat, dat|
           slot = @container.slots.find { |slot| slot.material_id==mat.id }
           expect(dat[:_id]).to eq(mat.id)
-          expect(dat[:container]).to eq({ barcode: @container.barcode, address: slot.address })
+          expect(dat[:container]).to eq({ barcode: @container.barcode, address: slot.address, num_of_rows: @container.num_of_rows, num_of_cols: @container.num_of_cols })
           expect(dat[:gender]).to eq(mat.attributes['gender'])
           expect(dat[:donor_id]).to eq(mat.attributes['donor_id'])
           expect(dat[:phenotype]).to eq(mat.attributes['phenotype'])
@@ -306,9 +306,9 @@ RSpec.describe WorkOrder, type: :model do
       @wo.describe_containers(@material_ids, material_data)
 
       expected = [
-        { barcode: @plate.barcode, address: 'A:3' },
-        { barcode: @plate.barcode, address: 'A:4' },
-        { barcode: @tube.barcode },
+        { barcode: @plate.barcode, address: 'A:3', num_of_cols: @plate.num_of_cols, num_of_rows: @plate.num_of_rows },
+        { barcode: @plate.barcode, address: 'A:4', num_of_cols: @plate.num_of_cols, num_of_rows: @plate.num_of_rows },
+        { barcode: @tube.barcode, address: 'A:1', num_of_cols: 1, num_of_rows: 1 },
       ]
       expect(material_data.length).to eq(expected.length)
       expected.zip(material_data).each do | exp, data |


### PR DESCRIPTION

Catalogues now post to /api/v1/catalogue .
Complete now posts to /api/v1/work_orders/{id}/complete .
Cancel now posts to /api/v1/work_orders/{id}/cancel .
Get the work order lims data from /api/v1/work_orders/{id} .
(Flimsy will need to be updated.)
Container information in lims data now includes num_of_rows
and num_of_cols, and includes address even for tubes.
Get returns the same json data that the application
posts to the LIMS when a work order is created.