### PR TITLE
Close comments

### DIFF
--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -63,7 +63,7 @@ class WorkOrder < ApplicationRecord
     status == WorkOrder.ACTIVE
   end
 
-  def submitted?
+  def closed?
     status == WorkOrder.COMPLETED || status == WorkOrder.CANCELLED
   end
 
@@ -185,11 +185,11 @@ class WorkOrder < ApplicationRecord
   end
 
   def generate_completed_and_cancel_event
-    if submitted?
+    if closed?
       message = EventMessage.new(work_order: self)
       EventService.publish(message)
     else
-      raise 'You cannot generate an event from a work order that has not been submitted.'
+      raise 'You cannot generate an event from a work order that has not been completed.'
     end
   end
 

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -119,7 +119,6 @@ class WorkOrder < ApplicationRecord
   end
 
   def all_results(result_set)
-    return result_set unless result_set.has_next?
     results = result_set.to_a
     while result_set.has_next? do
       result_set = result_set.next

--- a/app/services/completion_cancel_steps/update_work_order_step.rb
+++ b/app/services/completion_cancel_steps/update_work_order_step.rb
@@ -1,5 +1,5 @@
 class UpdateWorkOrderStep
-	attr_reader :status, :comment
+	attr_reader :old_status, :old_close_comment
 	def initialize(work_order, msg, finish_status)
 		@finish_status = finish_status
 		@work_order = work_order
@@ -8,15 +8,15 @@ class UpdateWorkOrderStep
 
 	# Step 4 - Update WorkOrder
 	def up
-		@status = @work_order.status
-		@comment = @work_order.comment
+		@old_status = @work_order.status
+		@old_close_comment = @work_order.close_comment
 		@work_order.update_attributes!(
-			status: @finish_status == 'complete' ? WorkOrder.COMPLETED : WorkOrder.CANCELLED,
-			comment: @msg[:work_order][:comment]
+			status: @finish_status.to_s == 'complete' ? WorkOrder.COMPLETED : WorkOrder.CANCELLED,
+			close_comment: @msg[:work_order][:comment]
 		)
 	end
 
 	def down
-		@work_order.update_attributes!(status: status, comment: comment)
+		@work_order.update_attributes!(status: old_status, close_comment: old_close_comment)
 	end
 end

--- a/app/views/application/_completion.html.erb
+++ b/app/views/application/_completion.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="col-md-12">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Closed with status</th>
+          <th>Comment</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><%= work_order.status %></td>
+          <td><%= work_order.close_comment %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/work_orders/_work_order.html.erb
+++ b/app/views/work_orders/_work_order.html.erb
@@ -3,7 +3,7 @@
   <td><%= work_order.product&.name || "None Selected" %></td>
   <td><%= work_order.updated_at %></td>
   <td>
-    <% if work_order.active? || work_order.submitted? %>
+    <% if work_order.active? || work_order.closed? %>
 
       <%= link_to 'View', work_order_path(work_order), class: 'btn btn-default' %>
 

--- a/app/views/work_orders/show.html.erb
+++ b/app/views/work_orders/show.html.erb
@@ -1,6 +1,9 @@
 <h4>Work order <%= work_order.id %></h2>
 
 <%= render 'work_orders' %>
+<% if work_order.closed? %>
+    <%= render 'completion' %>
+<% end %>
 <%= render 'sets' %>
 <%= render 'products' %>
 <%= render 'proposals' %>

--- a/db/migrate/20170914081304_add_close_comment_to_work_order.rb
+++ b/db/migrate/20170914081304_add_close_comment_to_work_order.rb
@@ -1,0 +1,5 @@
+class AddCloseCommentToWorkOrder < ActiveRecord::Migration[5.0]
+  def change
+    add_column :work_orders, :close_comment, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170718094004) do
+ActiveRecord::Schema.define(version: 20170914081304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20170718094004) do
     t.integer  "total_cost"
     t.string   "finished_set_uuid"
     t.string   "work_order_uuid"
+    t.string   "close_comment"
     t.index ["product_id"], name: "index_work_orders_on_product_id", using: :btree
   end
 

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe WorkOrder, type: :model do
         wo = build(:work_order)
         EventService = double('EventService')
         expect(EventService).not_to receive(:publish).with(an_instance_of(EventMessage))
-        expect{wo.generate_completed_and_cancel_event}.to raise_exception('You cannot generate an event from a work order that has not been submitted.')
+        expect{wo.generate_completed_and_cancel_event}.to raise_exception('You cannot generate an event from a work order that has not been completed.')
       end
     end
 

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe WorkOrder, type: :model do
   end
 
   def make_result_set(items)
-    rs = double('result_set', has_next?: false, length: items.length)
+    rs = double('result_set', has_next?: false, length: items.length, to_a: items)
     allow(rs).to receive(:map) { |&block| items.map(&block) }
     allow(rs).to receive(:each) { |&block| items.each(&block) }
     allow(rs).to receive(:all?) { |&block| items.all?(&block) }

--- a/spec/support/test_services_helper.rb
+++ b/spec/support/test_services_helper.rb
@@ -57,11 +57,9 @@ module TestServicesHelper
     allow(set).to receive(:materials).and_return(materials)
 
     result = double('response')
-    result_set = double('result_set')
+    result_set = double('result_set', to_a: materials, has_next?: false)
 
     allow(result).to receive(:result_set).and_return(result_set)
-
-    allow_any_instance_of(WorkOrder).to receive(:all_results).and_return(materials)
 
     allow(MatconClient::Material).to receive(:where).with("_id" => {"$in" => materials.map(&:id)}).and_return(result)
     allow(SetClient::Set).to receive(:find_with_materials).with(set_uuid).and_return([set])

--- a/spec/support/test_services_helper.rb
+++ b/spec/support/test_services_helper.rb
@@ -61,7 +61,7 @@ module TestServicesHelper
 
     allow(result).to receive(:result_set).and_return(result_set)
 
-    WorkOrder.any_instance.stub(:all_results).and_return(materials)
+    allow_any_instance_of(WorkOrder).to receive(:all_results).and_return(materials)
 
     allow(MatconClient::Material).to receive(:where).with("_id" => {"$in" => materials.map(&:id)}).and_return(result)
     allow(SetClient::Set).to receive(:find_with_materials).with(set_uuid).and_return([set])

--- a/spec/support/test_services_helper.rb
+++ b/spec/support/test_services_helper.rb
@@ -42,6 +42,7 @@ module TestServicesHelper
   def make_active_work_order
     work_order = instance_double("work_order", status: 'active',
       comment: 'any comment old',
+      close_comment: nil,
       user: instance_double("user", email: "user@here.com"))
   end
 


### PR DESCRIPTION
Store comments from completion/cancel in a separate field from
comments by the creator of the work order.