### PR TITLE
Remove UUID from step 1 of work order process

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       <li><%= link_to 'Creation', "#" %></li>
     </ul> -->
     <ul class="nav navbar-nav navbar-right">
-      <li><%= link_to 'Log Out', destroy_user_session_url, method: :delete if user_signed_in? %></li>
+      <li><%= link_to 'Log Out', destroy_user_session_path, method: :delete if user_signed_in? %></li>
     </ul>
     </div>
     </div>
@@ -43,7 +43,7 @@
       </div>
       <div class="col-md-4 text-right">
         <%= yield(:title_button) if content_for?(:title_button) %>
-        <%= link_to 'Log Out', destroy_user_session_url, class: 'btn btn-default vcenter', style: 'margin-top: 28px', method: :delete if user_signed_in? %>
+        <%= link_to 'Log Out', destroy_user_session_path, class: 'btn btn-default vcenter', style: 'margin-top: 28px', method: :delete if user_signed_in? %>
       </div>
     </div> -->
     <h1>Work Orders</h1>

--- a/app/views/orders/set.html.erb
+++ b/app/views/orders/set.html.erb
@@ -11,7 +11,6 @@
       <th>Set Name</th>
       <th>Size</th>
       <th>Created</th>
-      <th>ID</th>
     </tr>
   </thead>
 
@@ -32,9 +31,6 @@
         <td>
           <%= time_ago_in_words(s.created_at) + " ago" %>
         </td>
-        <td>
-          <%= s.uuid %>
-        </td>
       </tr>
       <% end %>
 
@@ -53,9 +49,6 @@
         </td>
         <td>
           <%= time_ago_in_words(s.created_at) + " ago" %>
-        </td>
-        <td>
-          <%= s.uuid %>
         </td>
       </tr>
       <% end %>

--- a/app/views/work_orders/index.html.erb
+++ b/app/views/work_orders/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title_button do %>
-  <%= link_to 'Create New Work Order', work_orders_url, method: 'post', class: 'btn btn-success vcenter' %>
+  <%= link_to 'Create New Work Order', work_orders_path, method: 'post', class: 'btn btn-success vcenter' %>
 <% end %>
 
 <div class="row">

--- a/spec/lib/event_publisher_spec.rb
+++ b/spec/lib/event_publisher_spec.rb
@@ -5,8 +5,8 @@ require 'set'
 RSpec.describe 'EventPublisher' do
 
   setup do
-    Bunny = double('Bunny')
-    allow_any_instance_of(EventPublisher).to receive(:add_close_connection_handler).and_return true    
+    Bunny ||= double('Bunny')
+    allow_any_instance_of(EventPublisher).to receive(:add_close_connection_handler).and_return true
   end
 
   def mock_connection(params)
@@ -14,7 +14,7 @@ RSpec.describe 'EventPublisher' do
     @channel = double('channel')
     @exchange = double('exchange')
     @queue = double('queue')
-    
+
     allow(@queue).to receive(:bind).with(@exchange).and_return(@queue)
     allow(@queue).to receive(:name).and_return("queue name")
     allow(Bunny).to receive(:new).with(params[:event_conn], threaded: false).and_return(@connection)
@@ -32,19 +32,19 @@ RSpec.describe 'EventPublisher' do
   context '#create_connection' do
 
     it 'initialize methods are called' do
-      
+
       allow_any_instance_of(EventPublisher).to receive(:set_config).and_return true
-      
+
       params = { event_conn: 'event conn', queue_name: 'queue name' }
       ep = EventPublisher.new(params)
       ep.create_connection
-      
+
       expect(ep).to have_received(:set_config)
       expect(ep).to have_received(:add_close_connection_handler)
     end
     it 'does not create connection if connection is already created' do
       params = { event_conn: 'event conn', queue_name: 'queue name' }
-      mock_connection(params)      
+      mock_connection(params)
       ep = EventPublisher.new(params)
 
       allow(ep).to receive(:connected?).and_return(true)
@@ -53,7 +53,7 @@ RSpec.describe 'EventPublisher' do
       ep.create_connection
 
       expect(ep).not_to have_received(:set_config)
-      expect(ep).not_to have_received(:add_close_connection_handler)      
+      expect(ep).not_to have_received(:add_close_connection_handler)
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe 'EventPublisher' do
 
       expect(@connection).to receive(:start)
       expect(@connection).to receive(:create_channel)
-      expect(@channel).to receive(:queue) 
+      expect(@channel).to receive(:queue)
 
       ep = EventPublisher.new(params)
       ep.create_connection
@@ -74,11 +74,11 @@ RSpec.describe 'EventPublisher' do
 
   context '#publish' do
     setup do
-      Bunny = double('Bunny')
+      Bunny ||= double('Bunny')
       @params = { event_conn: 'event_conn', queue_name: 'queue_name' }
       mock_connection(@params)
       @event_message = instance_double("EventMessage")
-      allow(@event_message).to receive(:generate_json).and_return("message")      
+      allow(@event_message).to receive(:generate_json).and_return("message")
 
       allow(@queue).to receive(:name).and_return(@params[:queue_name])
     end

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe WorkOrder, type: :model do
     context 'if work order does not have status completed or cancelled' do
       it 'generates an event using the EventService' do
         wo = build(:work_order)
-        EventService = double('EventService')
+        EventService ||= double('EventService')
         expect(EventService).not_to receive(:publish).with(an_instance_of(EventMessage))
         expect{wo.generate_completed_and_cancel_event}.to raise_exception('You cannot generate an event from a work order that has not been completed.')
       end
@@ -344,7 +344,7 @@ RSpec.describe WorkOrder, type: :model do
     context 'if work order does have status completed or cancelled' do
       it 'generates an event using the EventService' do
         wo = build(:work_order, status: 'completed')
-        EventService = double('EventService')
+        EventService ||= double('EventService')
         allow(EventService).to receive(:publish)
         expect(EventService).to receive(:publish).with(an_instance_of(EventMessage))
         wo.generate_completed_and_cancel_event
@@ -356,7 +356,7 @@ RSpec.describe WorkOrder, type: :model do
     context 'if work order does not have status active' do
       it 'generates an event using the EventService' do
         wo = build(:work_order)
-        EventService = double('EventService')
+        EventService ||= double('EventService')
         expect(EventService).not_to receive(:publish).with(an_instance_of(EventMessage))
         expect{wo.generate_submitted_event}.to raise_exception('You cannot generate an submitted event from a work order that is not active.')
       end
@@ -365,7 +365,7 @@ RSpec.describe WorkOrder, type: :model do
     context 'if work order does have status active' do
       it 'generates an event using the EventService' do
         wo = build(:work_order, status: 'active')
-        EventService = double('EventService')
+        EventService ||= double('EventService')
         allow(EventService).to receive(:publish)
         expect(EventService).to receive(:publish).with(an_instance_of(EventMessage))
         wo.generate_submitted_event


### PR DESCRIPTION
Also changed:
* Updated some spec files to re-use initialsed variables
* Changed _url to _path for 'Create New Work Order' and 'Log Out'
buttons