### PR TITLE
A155 use billing service to validate and display total price for the …

### DIFF
--- a/app/assets/javascripts/product_helper.js
+++ b/app/assets/javascripts/product_helper.js
@@ -1,26 +1,40 @@
 // Used to show the selected product and cost infomation in 'Select Product' step
 $(document).on("turbolinks:load", function() {
+
+  $.ajaxSetup({
+    headers: {
+      'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+    }
+  });
+
   $('#product-select').change(function(event){
     var productId = $("#product-select").val();
+    var workOrderId = $("#work-order-id").val();
 
     $.ajax({
-      headers: {
-          'Accept' : 'application/vnd.api+json',
-          'Content-Type' : 'application/vnd.api+json'
-      },
-      url: Routes.product_path(productId),
-      type: 'GET',
+      url: '/api/v1/work_orders/'+workOrderId+'/products/'+productId,
+      method: 'GET',
+      dataType: 'json',
+      contentType: 'application/json',
       success: function(data){
         renderProductInformation(data);
         renderCostInformation(data);
+      },
+      error: function() {
+        renderError('There was an error while accessing the Billing service');
       }
     });
   });
 });
 
+function renderError(msg) {
+  var errorMsg = '<div class="alert-danger alert alert-dismissible" role="alert">'+msg+'</div>';
+  $("#flash-display").html(errorMsg);
+}
+
 function renderProductInformation(data) {
   const product = {
-    cost_per_sample: convertToCurrency(data.cost_per_sample),
+    cost_per_sample: convertToCurrency(data.unit_price),
     requested_biomaterial_type: data.requested_biomaterial_type,
     product_version: data.product_version,
     tat: data.TAT,
@@ -36,7 +50,7 @@ function renderProductInformation(data) {
 
 function renderCostInformation(data) {
     const numOfSamples = $("#product-select").attr('num_of_samples');
-    const costPerSample = data.cost_per_sample;
+    const costPerSample = data.unit_price;
     const total = numOfSamples * costPerSample;
 
     const cost = {

--- a/app/controllers/catalogues_controller.rb
+++ b/app/controllers/catalogues_controller.rb
@@ -2,16 +2,25 @@ class CataloguesController < ApplicationController
   skip_authorization_check only: :create
   skip_credentials
 
+  before_action :validate_catalogue, only: [:create]
+
   # Currently using flimsy service to populate catalogue of products
   # Will not implement SSO just yet...
   # skip_authenticate_user
 
   def create
     Catalogue.create_with_products(catalogue_params)
-      head :created
+    head :created
   end
 
   private
+
+    def validate_catalogue
+      invalid_product_names = BillingFacadeClient.filter_invalid_product_names(catalogue_params[:products].map{|p| p[:name]})
+      unless invalid_product_names.length == 0
+        render status: 422, json: {errors: [message: "The Billing services does not validate the following products: #{invalid_product_names}"]}
+      end
+    end
 
     def catalogue_params
       params.require(:catalogue).permit(:url, :lims_id, :pipeline, products: [:name, :product_version,

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,9 +1,13 @@
 class ProductsController < ApplicationController
-  skip_authorization_check only: :show
-  skip_credentials
+  def show_product_inside_work_order
+    @work_order = WorkOrder.find(params[:id])
+    authorize! :read, @work_order
+    
+    @product = Product.find(params[:product_id])
+    cost_code = @work_order.proposal.cost_code
+    price = BillingFacadeClient.get_unit_price(cost_code, @product.name)
 
-  def show
-    @product = Product.find(params[:id])
-    render json: @product
+    render json: @product.as_json.merge(unit_price: price, cost_code: cost_code).to_json
   end
+
 end

--- a/app/models/catalogue.rb
+++ b/app/models/catalogue.rb
@@ -14,7 +14,7 @@ class Catalogue < ApplicationRecord
 
   		product_params.each do |pp|
         pp[:product_class] = Product.human_product_class_to_symbol(pp[:product_class] )
-  			Product.create!(pp.merge({ catalogue_id: catalogue_id, cost_per_sample: price_placeholder}))
+  			Product.create!(pp.merge({ catalogue_id: catalogue_id }))
   		end
   	end
   	catalogue

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -202,6 +202,7 @@ class WorkOrder < ApplicationRecord
     if closed?
       message = EventMessage.new(work_order: self, status: status)
       EventService.publish(message)
+      BillingFacadeClient.send_event(self, status)
     else
       raise 'You cannot generate an event from a work order that has not been completed.'
     end
@@ -211,6 +212,7 @@ class WorkOrder < ApplicationRecord
     if active?
       message = EventMessage.new(work_order: self, status: 'submitted')
       EventService.publish(message)
+      BillingFacadeClient.send_event(self, 'submitted')
     else
       raise 'You cannot generate an submitted event from a work order that is not active.'
     end

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-12">
+  <div class="col-md-12" id="flash-display">
     <% flash.each do |key, value| %>
         <div class="alert-<%= key %> alert alert-dismissible" role="alert">
           <button type="button" class="close" data-dismiss="alert">

--- a/app/views/application/_products.html.erb
+++ b/app/views/application/_products.html.erb
@@ -16,7 +16,7 @@
 				<tr>
 					<td><%= work_order.product.name %></td>
 					<td><%= work_order.product.product_version %></td>
-					<td><%= number_to_currency(work_order.product.cost_per_sample, unit:'£') %></td>
+					<td><%= number_to_currency(work_order.cost_per_sample, unit:'£') %></td>
 					<td><%= work_order.product.requested_biomaterial_type %></td>
 					<td><%= work_order.product.TAT %></td>
 					<td><%= work_order.product.description %></td>

--- a/app/views/orders/product.html.erb
+++ b/app/views/orders/product.html.erb
@@ -5,7 +5,7 @@
   <%= f.select :product_id, grouped_options_for_select(get_current_catalogues_with_products, work_order.product_id),
     { label: "Choose a product:" },
     { class: "selectpicker", id: "product-select", num_of_samples: work_order.num_samples } %>
-
+  <input type='hidden' disabled='disabled' id="work-order-id" value="<%= work_order.id %>" />
   <div id="product-information" style="display:none"></div>
   <div id="cost-information" style="display:none"></div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,8 @@ Rails.application.configure do
 
   config.work_order_completion_json = 'work_order_completion.json'
 
+  config.billing_facade_url = 'http://localhost:3601'
+
   config.fake_ldap = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,6 +50,8 @@ Rails.application.configure do
 
   config.stamp_url = 'http://external-server:7000/api/v1'
 
+  config.billing_facade_url = 'http://external-server:3601'
+
   config.work_order_completion_json = 'work_order_completion.json'
 
   config.jwt_secret_key = 'test'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,13 @@ Rails.application.routes.draw do
       post 'complete', to: 'work_orders#complete'
       post 'cancel', to: 'work_orders#cancel'
       get '', to: 'work_orders#get'
+
+      get 'products/:product_id', to: 'products#show_product_inside_work_order'
     end
   end
 
   resources :work_orders do
   	resources :build, controller: 'orders'
   end
-
-  resources :products, only: [:show]
 
 end

--- a/db/migrate/20171019104645_remove_cost_per_sample_from_products.rb
+++ b/db/migrate/20171019104645_remove_cost_per_sample_from_products.rb
@@ -1,0 +1,9 @@
+class RemoveCostPerSampleFromProducts < ActiveRecord::Migration[5.0]
+  def change
+    ActiveRecord::Base.transaction do
+      add_column :work_orders, :cost_per_sample, :decimal, precision: 8, scale: 2
+      change_column :work_orders, :total_cost, :decimal, precision: 8, scale: 2
+      remove_column :products, :cost_per_sample
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170925150957) do
+ActiveRecord::Schema.define(version: 20171019104645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,14 +39,13 @@ ActiveRecord::Schema.define(version: 20170925150957) do
 
   create_table "products", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",                                                     null: false
-    t.datetime "updated_at",                                                     null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "catalogue_id"
     t.integer  "TAT"
-    t.decimal  "cost_per_sample",            precision: 8, scale: 2
     t.string   "requested_biomaterial_type"
     t.integer  "product_version"
-    t.integer  "availability",                                       default: 1
+    t.integer  "availability",               default: 1
     t.string   "description"
     t.string   "product_uuid"
     t.integer  "product_class"
@@ -55,19 +54,20 @@ ActiveRecord::Schema.define(version: 20170925150957) do
 
   create_table "work_orders", force: :cascade do |t|
     t.string   "status"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.string   "original_set_uuid"
     t.string   "set_uuid"
     t.integer  "proposal_id"
     t.string   "comment"
     t.date     "desired_date"
     t.integer  "product_id"
-    t.integer  "total_cost"
+    t.decimal  "total_cost",        precision: 8, scale: 2
     t.string   "finished_set_uuid"
     t.string   "work_order_uuid"
     t.string   "close_comment"
     t.string   "owner_email"
+    t.decimal  "cost_per_sample",   precision: 8, scale: 2
     t.index ["owner_email"], name: "index_work_orders_on_owner_email", using: :btree
     t.index ["product_id"], name: "index_work_orders_on_product_id", using: :btree
   end

--- a/features/create_order.feature
+++ b/features/create_order.feature
@@ -29,6 +29,10 @@ Given the following proposals have been defined:
 | Proposal 1 | 1     |
 | Proposal 2 | 2     |
 
+Given the following unit prices are defined by the Billing service:
+| Cost Code | Product Name   | Unit Price |
+| 1         | product_test_1 | 17.4       |
+| 2         | product_test_2 | 32.33      |
 
 Scenario: Receiving a catalogue
 
@@ -61,7 +65,7 @@ Then I should be on the step: "Select Product"
 And I should see "Choose a product:"
 Then I click on drop-down "product-select"
 Then I click on "product_test_1" in drop-down "product-select"
-And I should see "Total : £0.00"
+And I should see "Total : £52.20"
 And I click on "Next"
 
 Then I should be on the step: "Confirm"
@@ -69,7 +73,7 @@ And I should see "testing_set_1"
 And I should see "product_test_1"
 And I should see "Proposal 1"
 And I should see "Transcriptomics"
-And I should see "£0.00"
+And I should see "£52.20"
 
 When I save the order
 

--- a/lib/billing_facade_client.rb
+++ b/lib/billing_facade_client.rb
@@ -1,0 +1,62 @@
+require 'faraday'
+require 'bigdecimal'
+
+module BillingFacadeClient
+
+  def self.send_event(work_order, name)
+    connection.post("/events", {eventName: name, workOrderId: work_order.id}.to_json)
+    return true if r.status==200
+    return false
+  end
+
+  def self.validate_single_value(path)
+    r = connection.get(path)
+    return false unless r.status == 200
+    response = JSON.parse(r.body, symbolize_names: true)
+    return response[:verified]
+  end
+
+  def self.validate_multiple_values(path, params)
+    r = connection.post(path, params.to_json )
+    return [] if r.status==200
+    response = JSON.parse(r.body, symbolize_names: true)
+    invalid_cost_codes = response.keys.select{|cost_code| !response[cost_code] }
+    return invalid_cost_codes    
+  end
+
+  def self.get_cost_information_for_products(cost_code, product_names)
+    r = connection.post("/accounts/#{cost_code}/unit_price", product_names.to_json)
+    response = JSON.parse(r.body, symbolize_names: true)
+    return response
+  end
+
+  def self.get_unit_price(cost_code, product_name)
+    response = get_cost_information_for_products(cost_code, [product_name]).first
+    if response && response[:verified]
+      return BigDecimal.new(response[:unitPrice])
+    else
+      return nil
+    end    
+  end
+
+  def self.validate_product_name?(product_name)
+    validate_single_value("/products/#{product_name}/verify")
+  end
+
+  def self.validate_cost_code?(cost_code)
+    validate_single_value("/accounts/#{cost_code}/verify")
+  end
+
+  def self.filter_invalid_cost_codes(cost_codes)
+    validate_multiple_values("/accounts/verify", {accounts: cost_codes})
+  end
+
+  def self.filter_invalid_product_names(product_names_list)
+    validate_multiple_values("/catalogue/verify", {products: product_names_list})
+  end
+
+  def self.connection
+    Faraday.new(:url => Rails.application.config.billing_facade_url, 
+      headers: {'Content-Type': 'application/json', "Accept" => "application/json"})
+  end
+end

--- a/spec/controllers/catalogues_controller_spec.rb
+++ b/spec/controllers/catalogues_controller_spec.rb
@@ -12,17 +12,64 @@ RSpec.describe CataloguesController, type: :controller do
       { "Content-Type" => "application/json" }
     end
 
+    let(:BillingFacadeClient) { double('facade') }
+    
+
     context "when posting to /catalogue" do
       it "calls create_with_products method in the model" do
+        allow(BillingFacadeClient).to receive(:filter_invalid_product_names).and_return([])
+
         if user
           allow_any_instance_of(CataloguesController).to receive(:check_credentials)
           allow_any_instance_of(CataloguesController).to receive(:current_user)
         end
         expect(Catalogue).to receive(:create_with_products)
 
-        post :create, params: { catalogue: {lims_id: 'a', pipeline: 'b', url: 'c', products: [] } }, headers: headers
+        post :create, params: { catalogue: {lims_id: 'a', pipeline: 'b', url: 'c', products: [{name: 'a name'}] } }, headers: headers
         expect(response).to have_http_status(:created)
       end
+
+      context 'when validating a catalogue' do
+        
+        let(:products) {[{name: 'name1'}, {name: 'another'}]}
+        let(:product_names) { products.map{|p| p[:name]} }
+        let(:catalogue) { { catalogue: {lims_id: 'a', pipeline: 'b', url: 'c', products: products } } } 
+
+
+        context 'when the billing service is running' do
+          it 'uses the billing facade to validate it' do
+            expect(BillingFacadeClient).to receive(:filter_invalid_product_names).with(product_names).and_return([])
+            post :create, params: catalogue, headers: headers
+          end
+
+          context 'when the product names of the catalogue are valid' do
+            setup do
+              allow(BillingFacadeClient).to receive(:filter_invalid_product_names).and_return([])
+            end
+            it 'returns a created response' do
+              post :create, params: catalogue, headers: headers
+              expect(response).to have_http_status(:created)
+            end
+          end
+          context 'when the product names are not valid' do
+            setup do
+              allow(BillingFacadeClient).to receive(:filter_invalid_product_names).and_return([product_names.first])
+            end
+
+            it 'returns a 422' do
+              post :create, params: catalogue, headers: headers
+              expect(response).to have_http_status(422)
+            end
+
+            it 'returns the list of errored product names' do
+              post :create, params: catalogue, headers: headers
+              expect(response.body.include?(product_names.first)).to eq(true)
+            end
+          end
+        end
+      end
+
+      
     end
 
   end

--- a/spec/integration/catalogues_spec.rb
+++ b/spec/integration/catalogues_spec.rb
@@ -9,6 +9,7 @@ describe 'Catalogues API' do
   before do
     webmock_matcon_schema
     allow_set_service_lock_set
+    allow_billing_service_validate_all
   end
 
 

--- a/spec/integration/work_orders_spec.rb
+++ b/spec/integration/work_orders_spec.rb
@@ -10,6 +10,8 @@ describe 'Work Orders API' do
   before do
     webmock_matcon_schema
     allow_set_service_lock_set
+
+    allow(BillingFacadeClient).to receive(:send_event)
   end
 
 

--- a/spec/lib/billing_facade_client_spec.rb
+++ b/spec/lib/billing_facade_client_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+RSpec.describe('BillingFacadeClient') do
+  let(:billing_url) { Rails.application.config.billing_facade_url }
+  context '#validate_single_value' do
+
+    let(:path) { '/anypath'}
+    let(:url) {billing_url + path }
+
+    context 'when the status received is 200' do
+      setup do
+        stub_request(:get, url).
+          to_return(status: 200, body: {verified: true }.to_json)        
+      end
+      it 'returns the value of the field verified' do
+        expect(BillingFacadeClient.validate_single_value(path)).to eq(true)
+      end
+    end
+
+    context 'when the status received is not 200' do
+      setup do
+        stub_request(:get, url).
+          to_return(status: 404, body: nil)
+      end      
+      it 'returns false' do
+        expect(BillingFacadeClient.validate_single_value(path)).to eq(false)
+      end
+    end
+  end
+  context '#validate_multiple_values' do
+
+    let(:path) { '/anypath'}
+    let(:url) {billing_url + path }
+    let(:params) { ['a','b','c']}
+
+    context 'when the status received is not 200' do
+      it 'returns the list of keys of the object whom value is false' do
+        stub_request(:post, url).with(body: params.to_json).
+          to_return(status: 400, body: {'a': false, 'b': true, 'c': false }.to_json)        
+        expect(BillingFacadeClient.validate_multiple_values(path, params)).to eq([:a,:c])
+      end
+      it 'returns an empty list when the object obtained is empty' do
+        stub_request(:post, url).with(body: params.to_json).
+          to_return(status: 400, body: {}.to_json)        
+        expect(BillingFacadeClient.validate_multiple_values(path, params)).to eq([])        
+      end
+      it 'returns an empty list when the object obtained does not have invalid values' do
+        stub_request(:post, url).with(body: params.to_json).
+          to_return(status: 400, body: {'a': true, 'b': true, 'c': true }.to_json)        
+        expect(BillingFacadeClient.validate_multiple_values(path, params)).to eq([])        
+      end
+    end
+
+    context 'when the status received is 200' do
+      setup do
+        stub_request(:post, url).with(body: params.to_json).
+          to_return(status: 200, body: {'a': false, 'b': true, 'c': false }.to_json)
+      end      
+      it 'returns an empty list' do
+        expect(BillingFacadeClient.validate_multiple_values(path, params)).to eq([])
+      end
+    end
+
+  end
+  context '#get_cost_information_for_products' do
+    let(:cost_code) {'code'}
+    let(:url) {billing_url + "/accounts/#{cost_code}/unit_price"}
+    let(:product_names) { ['a','b','c'] }
+
+    it 'performs a call to the unit price action for the proposal' do
+      data = [{my: true, data: false}]
+      stub_request(:post, url).with(body: product_names.to_json).
+        to_return(status: 200, body: data.to_json)
+      expect(BillingFacadeClient.get_cost_information_for_products(cost_code, product_names)).to eq(data)
+    end
+  end
+  context '#get_unit_price' do
+    let(:cost_code) {'code'}
+    let(:product_name) {'a product name'}
+    let(:unit_price) { "33.3" }
+    context 'when there is no unit price defined for the pair [cost code, product name]' do
+      setup do
+        allow(BillingFacadeClient).to receive(:get_cost_information_for_products)
+          .with(cost_code, [product_name])
+            .and_return([])
+      end
+
+      it 'returns nil ' do
+        expect(BillingFacadeClient.get_unit_price(cost_code, product_name)).to eq(nil)
+      end
+    end
+    context 'when there is a unit price defined' do
+      context 'when the price is not verified by the billing service' do
+        setup do
+          allow(BillingFacadeClient).to receive(:get_cost_information_for_products)
+            .with(cost_code, [product_name])
+              .and_return([{unitPrice: unit_price, verified: false}])
+        end
+
+        it 'returns nil' do
+          expect(BillingFacadeClient.get_unit_price(cost_code, product_name)).to eq(nil)
+        end
+      end
+      context 'when the price is verified by the billing service' do
+        setup do
+          allow(BillingFacadeClient).to receive(:get_cost_information_for_products)
+            .with(cost_code, [product_name])
+              .and_return([{unitPrice: unit_price, verified: true}])
+        end
+
+        it 'returns the unit price' do
+          expect(BillingFacadeClient.get_unit_price(cost_code, product_name)).to eq(BigDecimal.new(unit_price))
+        end
+        it 'is a BigDecimal data type' do
+          expect(BillingFacadeClient.get_unit_price(cost_code, product_name).kind_of? BigDecimal).to eq(true)
+        end
+      end
+    end
+  end
+  context '#validate_product_name?' do
+    it 'validates using the url' do
+      expect(BillingFacadeClient).to receive(:validate_single_value).with('/products/product1/verify')
+      BillingFacadeClient.validate_product_name?('product1')
+    end
+  end
+  context '#validate_cost_code?' do
+    it 'validates using the url' do
+      expect(BillingFacadeClient).to receive(:validate_single_value).with('/accounts/cost1/verify')
+      BillingFacadeClient.validate_cost_code?('cost1')
+    end    
+  end
+  context '#filter_invalid_cost_codes' do
+    it 'validates using the url' do
+      cost_codes = ['a','b']
+      expect(BillingFacadeClient).to receive(:validate_multiple_values).with('/accounts/verify', {accounts: cost_codes})
+      BillingFacadeClient.filter_invalid_cost_codes(cost_codes)
+    end    
+  end
+  context '#filter_invalid_product_names' do
+    it 'validates using the url' do
+      product_names = ['a','b']
+      expect(BillingFacadeClient).to receive(:validate_multiple_values).with('/catalogue/verify', {products: product_names})
+      BillingFacadeClient.filter_invalid_product_names(product_names)
+    end        
+  end
+  context '#connection' do
+    it 'creates a new connection' do
+      expect(Faraday).to receive(:new)
+      BillingFacadeClient.connection
+    end
+  end
+end

--- a/spec/models/catalogue_spec.rb
+++ b/spec/models/catalogue_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Catalogue, type: :model do
         product = products.first
         expect(product.name).to eq "Cake"
         expect(product.description).to eq "delicious"
-        expect(product.cost_per_sample).to eq 0
         expect(product.product_class).to eq 'dna_sequencing'
       end
 

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -362,6 +362,7 @@ RSpec.describe WorkOrder, type: :model do
         wo = build(:work_order, status: 'completed')
         EventService ||= double('EventService')
         allow(EventService).to receive(:publish)
+        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'completed')
         expect(EventService).to receive(:publish).with(an_instance_of(EventMessage))
         wo.generate_completed_and_cancel_event
       end
@@ -373,6 +374,7 @@ RSpec.describe WorkOrder, type: :model do
       it 'generates an event using the EventService' do
         wo = build(:work_order)
         EventService ||= double('EventService')
+        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'submitted')
         expect(EventService).not_to receive(:publish).with(an_instance_of(EventMessage))
         expect{wo.generate_submitted_event}.to raise_exception('You cannot generate an submitted event from a work order that is not active.')
       end
@@ -383,6 +385,7 @@ RSpec.describe WorkOrder, type: :model do
         wo = build(:work_order, status: 'active')
         EventService ||= double('EventService')
         allow(EventService).to receive(:publish)
+        allow(BillingFacadeClient).to receive(:send_event).with(wo, 'submitted')
         expect(EventService).to receive(:publish).with(an_instance_of(EventMessage))
         wo.generate_submitted_event
       end

--- a/spec/services/update_order_service_spec.rb
+++ b/spec/services/update_order_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UpdateOrderService do
 
   def make_product(attrs=nil)
     @c1 = create(:catalogue)
-    x = { cost_per_sample: 5, catalogue_id: @c1.id }
+    x = { catalogue_id: @c1.id }
     x.merge!(attrs) if attrs
     create(:product, x)
   end
@@ -41,7 +41,8 @@ RSpec.describe UpdateOrderService do
     return create(:work_order, attrs) if step==:product
     @product = make_product
     attrs[:product_id] = @product.id
-    attrs[:total_cost] = @product.cost_per_sample*@clone_set.meta['size']
+    attrs[:cost_per_sample] = 17
+    attrs[:total_cost] = attrs[:cost_per_sample]*@clone_set.meta['size']
 
     return create(:work_order, attrs) if step==:cost
 
@@ -65,6 +66,7 @@ RSpec.describe UpdateOrderService do
 
     context "when the work order has a set" do
       before do
+        allow(BillingFacadeClient).to receive(:validate_cost_code?).and_return(true)
         @wo = order_at_step(:product)
       end
 
@@ -165,22 +167,38 @@ RSpec.describe UpdateOrderService do
         @wo = order_at_step(:proposal)
       end
 
-      it "should accept a proposal id" do
-        proposal = make_proposal
-        params = { 'proposal_id' => proposal.id }
-        messages = {}
-        expect(UpdateOrderService.new(params, @wo, messages).perform(:proposal)).to eq(true)
-        expect(messages[:error]).to be_nil
-
-        expect(@wo.proposal_id).to eq(proposal.id)
-        expect(@wo.status).to eq('product')
-      end
-
       it "should refuse a later step" do
         params = {}
         messages = {}
         expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(false)
         expect(messages[:error]).to include('project')
+      end
+
+      context "when the billing service validates the proposal" do
+        before do
+          allow(BillingFacadeClient).to receive(:validate_cost_code?).and_return(true)
+        end
+        it "should accept a proposal id" do
+          proposal = make_proposal
+          params = { 'proposal_id' => proposal.id }
+          messages = {}
+          expect(UpdateOrderService.new(params, @wo, messages).perform(:proposal)).to eq(true)
+          expect(messages[:error]).to be_nil
+
+          expect(@wo.proposal_id).to eq(proposal.id)
+          expect(@wo.status).to eq('product')
+        end
+      end
+
+      context "when the billing service does not validate the proposal" do
+        it "should fail if the cost code of the proposal is not validated by the billing service" do
+          proposal = make_proposal
+          params = { 'proposal_id' => proposal.id }
+          allow(BillingFacadeClient).to receive(:validate_cost_code?).and_return(false)
+          messages = {}
+          expect(UpdateOrderService.new(params, @wo, messages).perform(:proposal)).to eq(false)
+          expect(messages[:error]).to include('Billing')
+        end        
       end
     end
 
@@ -192,13 +210,18 @@ RSpec.describe UpdateOrderService do
       it "should accept a product" do
         expect(@wo.total_cost).to be_nil
         product = make_product
+
+        unit_cost = BigDecimal.new(17)
+        allow(BillingFacadeClient).to receive(:get_unit_price)
+          .with(@wo.proposal.cost_code, product.name).and_return(unit_cost)
+
         params = { 'product_id' => product.id }
         messages = {}
         expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(true)
         expect(messages[:error]).to be_nil
 
         expect(@wo.product).to eq(product)
-        expect(@wo.total_cost).to eq(@clone_set.meta['size']*product.cost_per_sample)
+        expect(@wo.total_cost).to eq(@clone_set.meta['size']*@wo.cost_per_sample)
         expect(@wo.status).to eq('cost')
       end
 
@@ -210,53 +233,63 @@ RSpec.describe UpdateOrderService do
       end
 
       it "should fail if the cost cannot be calculated" do
-        product = make_product(cost_per_sample: nil)
+        product = make_product
+
+        unit_cost = nil
+        allow(BillingFacadeClient).to receive(:get_unit_price)
+          .with(@wo.proposal.cost_code, product.name).and_return(unit_cost)
+
         params = { 'product_id' => product.id }
         messages = {}
         expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(false)
         expect(messages[:error]).to include('cost')
       end
-    end
 
-    context "when work order is at cost step" do
-      before do
-        @wo = order_at_step(:cost)
+      context "when a product is selected" do
+        let(:product) { make_product}
+
+        context "given we previously selected a proposal" do
+          let(:proposal) { @wo.proposal }
+          let(:cost_code) { @wo.proposal.cost_code }
+          let(:unit_price) { BigDecimal.new(17) }
+
+          context "when the unit price is verified by the billing service" do
+            it "should display the total cost for the product" do
+              allow(BillingFacadeClient).to receive(:get_unit_price).with(cost_code, product.name)
+                  .and_return(unit_price)
+
+              expect(BillingFacadeClient).to receive(:get_unit_price)
+                .with(cost_code, product.name)
+
+              params = { 'product_id' => product.id }
+              messages = {}
+              expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(true)
+
+            end
+          end
+          context "when the unit price is not verified by the billing service" do
+            it "should fail and display an error message" do
+              allow(BillingFacadeClient).to receive(:get_unit_price).with(cost_code, product.name)
+                  .and_return(nil)
+
+              params = { 'product_id' => product.id }
+              messages = {}
+              expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(false)
+              expect(messages[:error]).to include('missing product cost')
+            end
+          end
+        end
       end
-
-      context "when you revise the product step" do
-        before do
-          @product = make_product(cost_per_sample: 31)
-
-          expect(@wo.product).not_to eq(@product)
-          params = { 'product_id' => @product.id }
-          @messages = {}
-          @result = UpdateOrderService.new(params, @wo, @messages).perform(:product)
-        end
-
-        it "should return true" do
-          expect(@result).to eq(true)
-        end
-        it "should have no error" do
-          expect(@messages[:error]).to be_nil
-        end
-        it "should update the product" do
-          expect(@wo.product).to eq(@product)
-          expect(@wo.product_id).to eq(@product.id)
-        end
-        it "should recalculate the total cost" do
-          expect(@wo.total_cost).to eq(@wo.set.meta['size']*@product.cost_per_sample)
-        end
-        it "should go back to the cost step" do
-          expect(@wo.status).to eq('cost')
-        end
-      end
-
     end
 
     context "when work order is at summary step" do
       before do
         @wo = order_at_step(:summary)
         allow(@wo).to receive(:send_to_lims)
+      end
+
+      it "should have a total cost that can be obtained from unit prices and num samples" do
+        expect(@wo.total_cost).to eq(@wo.cost_per_sample * @wo.set.meta['size'])
       end
 
       it "should refuse if the product is suspended" do
@@ -285,6 +318,11 @@ RSpec.describe UpdateOrderService do
       it "should let you alter an earlier step" do
         product = make_product
         expect(@wo.product).not_to eq(product)
+
+        unit_cost = BigDecimal.new(17)
+        allow(BillingFacadeClient).to receive(:get_unit_price)
+          .with(@wo.proposal.cost_code, product.name).and_return(unit_cost)
+
         params = { 'product_id' => product.id }
         messages = {}
         expect(UpdateOrderService.new(params, @wo, messages).perform(:product)).to eq(true)

--- a/spec/support/test_services_helper.rb
+++ b/spec/support/test_services_helper.rb
@@ -9,6 +9,11 @@ module TestServicesHelper
     allow(double_set).to receive(:update_attributes)
   end
 
+  def allow_billing_service_validate_all
+    allow(BillingFacadeClient).to receive(:filter_invalid_product_names).and_return([])
+  end
+
+
   def webmock_containers_schema
     @container_schema = %Q{
       {"required": ["num_of_cols", "num_of_rows", "col_is_alpha", "row_is_alpha"], "type": "object", "properties": {"num_of_cols": {"max": 9999, "col_alpha_range": true, "required": true, "type": "integer", "min": 1}, "barcode": {"non_aker_barcode": true, "minlength": 6, "unique": true, "type": "string"}, "num_of_rows": {"row_alpha_range": true, "max": 9999, "required": true, "type": "integer", "min": 1}, "col_is_alpha": {"required": true, "type": "boolean"}, "print_count": {"max": 9999, "required": false, "type": "integer", "min": 0}, "row_is_alpha": {"required": true, "type": "boolean"}, "slots": {"uniqueaddresses": true, "type": "list", "schema": {"type": "dict", "schema": {"material": {"type": "uuid", "data_relation": {"field": "_id", "resource": "materials", "embeddable": true}}, "address": {"type": "string", "address": true}}}}}}


### PR DESCRIPTION
…work order (#102)

* Added billing facade client
Validation of catalogue using the billing facade to test the product names
Unit tests and integration tests

* Check with the billing service if the cost code is valid when it is selected
while creating a work order

* Only authenticated users can access the product price
Added CSRF header for ajax when getting the product price for the work order
Removed cost_per_sample column from product. This value is going to be obtained from
the billing service depending in a couple of conditions, so we'll store the
value in work order instead.
Added cost_per_sample and total cost to work order, to be able to know the values
presented to the user on work order creation. Both values will be decimal
stored.
BillingFacade client will return a BigDecimal when returning the unit price,
or nil when the unit price is not defined.
Added route to obtain the information of a product inside the scope of a work
order. This is use for adding the information of the cost of the product for
that particular work order. The proposal selected and the product selected
are send to the billing service to obtain the unit cost, and this unit cost
is merged in the product.json obtained.
Added unit tests and integration tests.

* Adds call to tell the billing facade service that the submission is submitted,
completed or cancelled

* Capybara browser in use is not compatible with some new syntax of ES6 and
that was stopping some tests to work.

* Updated from comments