### PR TITLE
Work Orders UX

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -114,17 +114,26 @@ h2 {
   .bs-wizard-step > .progress {
     position: absolute;
     width: 100%;
-    height: 8px;
-    background: #4CAF50;
     top: 47px;
-    margin-top: 20px;
-  }
-  .bs-wizard-step > .step-indicator {
-    margin-top: 10px;
+    margin-top: -3px;
   }
   .row#progress-bar {
     margin-bottom: 50px;
   }
+}
+@media only screen and (max-width: 516px)  {
+  .bs-wizard-step > .progress {
+    margin-top: 10px;
+  }
+  .bs-wizard-step > .step-indicator {
+    margin-top: 0px;
+  }
+  .row#progress-bar {
+    margin-bottom: 50px;
+  }
+}
+.active {
+  pointer-events: none;
 }
 
 .navbar-text {

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -60,6 +60,11 @@ class WorkOrder < ApplicationRecord
     [WorkOrder.ACTIVE, WorkOrder.BROKEN, WorkOrder.COMPLETED, WorkOrder.CANCELLED]
   end
 
+  def pending?
+    # Returns true if the work order wizard has not yet been completed
+    WorkOrder.not_pending_status_list.exclude?(status)
+  end
+
   def active?
     status == WorkOrder.ACTIVE
   end

--- a/app/views/application/_sets.html.erb
+++ b/app/views/application/_sets.html.erb
@@ -11,7 +11,7 @@
         <tr>
           <td><%= work_order.set.name %></td>
           <td><%= link_to 'View', "#{Rails.configuration.urls[:sets]}/simple/sets/#{work_order.set_uuid}", class: 'btn btn-default', style: "margin-right: 10px;" %>
-            <%= link_to 'Order Work', work_orders_path(set_id: work_order.set_uuid), method: 'post', class: 'btn btn-success' %></td>
+            <%= link_to 'Order Work', work_orders_path(set_id: work_order.set_uuid), method: 'post', class: 'btn btn-success' unless work_order.pending? %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,9 +53,15 @@
     </div>
     </nav>
 
-  <div class="container" id="content">
+    <div class="row">
+      <div class="col-md-8">
+        <h1>Work Orders</h1>
+      </div>
+      <div class="col-md-4">
+        <%= yield(:title_button) if content_for?(:title_button) %>
+      </div>
+    </div>
 
-    <h1>Work Orders</h1>
     <%= render "flashes" %>
     <%= yield(:title_button) if content_for?(:title_button) %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,6 +53,7 @@
     </div>
     </nav>
 
+  <div class="container" id="content">
     <div class="row">
       <div class="col-md-8">
         <h1>Work Orders</h1>
@@ -63,8 +64,6 @@
     </div>
 
     <%= render "flashes" %>
-    <%= yield(:title_button) if content_for?(:title_button) %>
-
     <%= yield %>
 
   </div>

--- a/app/views/orders/_buttons.html.erb
+++ b/app/views/orders/_buttons.html.erb
@@ -1,22 +1,24 @@
 <div class="row">
   <div class="col-md-12">
     <div style="margin: 10px 0">
-      <% unless first_step? %>
-        <%= link_to 'Back', previous_wizard_path, class: 'btn btn-default' %>
+      <% if (last_step?) %>
+        <%= f.submit "Save & Exit", class: "btn btn-success pull-right" %>
+      <% else %>
+        <%= f.submit "Next", class: "btn btn-primary pull-right" %>
       <% end %>
 
-      <% if (last_step?) %>
-        <%= f.submit "Save & Exit", class: "btn btn-primary", style: "float: right" %>
-      <% else %>
-        <%= f.submit "Next", class: "btn btn-default", style: "float: right" %>
+      <% unless first_step? %>
+        <%= link_to 'Previous', previous_wizard_path,
+              class: 'btn btn-warning',
+              data: { confirm: 'Are you sure you wish to go back? You will loose any progress on the curent step' },
+              style: "margin-right: 10px;" %>
       <% end %>
 
       <% unless work_order.active? %>
-        <%= link_to 'Cancel', work_order,
+        <%= link_to 'Cancel Work Order', work_order,
               method: :delete,
               class: 'btn btn-danger',
-              data: { confirm: 'Are you sure you wish to cancel this work order?' },
-              style: "float: right; margin-right: 7px"
+              data: { confirm: 'Are you sure you wish to cancel this work order?' }
         %>
       <% end %>
     </div>

--- a/app/views/orders/_order_header.html.erb
+++ b/app/views/orders/_order_header.html.erb
@@ -5,7 +5,8 @@
       <div class="progress">
         <div class="progress-bar"></div>
       </div>
-      <a href="#" class="step-indicator"></a>
+      <%= link_to '', step.to_s, class: "step-indicator",
+            data: { confirm: 'Are you sure you wish to go back? You will loose any progress on the curent step' } %>
     </div>
   <% end %>
 </div>

--- a/app/views/work_orders/_work_order.html.erb
+++ b/app/views/work_orders/_work_order.html.erb
@@ -9,7 +9,7 @@
 
     <% else %>
 
-      <%= link_to 'Continue', work_order_build_path(id: work_order.status, work_order_id: work_order.id), class: 'btn btn-primary' %>
+      <%= link_to 'Continue', work_order_build_path(id: work_order.status, work_order_id: work_order.id), class: 'btn btn-primary', style: "margin-right: 10px" %>
 
       <%= link_to 'Cancel', work_order,
             method: :delete,

--- a/app/views/work_orders/index.html.erb
+++ b/app/views/work_orders/index.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title_button do %>
-  <%= link_to 'Create New Work Order', work_orders_path, method: 'post', class: 'btn btn-success vcenter' %>
+  <%= link_to 'Create New Work Order', work_orders_path, method: 'post',
+        class: 'btn btn-success pull-right',
+        style: "margin-top: 23px" %>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
- The "Back" button on the work order step has been renamed to "Previous" and given the warning class, so it'll appear orange, as going back will cause you to lose changes that haven't already been saved
- The bulges are also clickable to go back to a specific earlier step
- When attempting to go to a previous step, a warning will appear so they user can acknowledge they may lose data when going back
- Small tweaks to the positioning of the bulges on mobile, so they don't overlap with text
- Destructive actions (previous and cancel) are grouped together in the lower left of the wizard, while next remains on the right
- The "Order Work" button would (confusingly) appear on the Work Order summary page. This button is now hidden for work orders that haven't yet been submitted by the user.

**Before**
![screen shot 2017-10-31 at 14 54 11](https://user-images.githubusercontent.com/18176485/32230579-67262b2c-be4b-11e7-919d-c84dc9a82c38.png)
**After**
![screen shot 2017-10-31 at 14 53 46](https://user-images.githubusercontent.com/18176485/32230578-66ff0614-be4b-11e7-9dc2-f364aebcf0af.png)


