### PR TITLE
Converting some columns to citext and adding sanitisation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,9 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-permission.git
-  revision: 39dead14c5ad4da60271dc2408a3208333b89407
+  revision: 3c8ea05a11a558bb912b84085323990e1192e64b
   specs:
-    aker_permission_gem (0.4.0)
+    aker_permission_gem (0.4.1)
       cancancan
 
 GIT
@@ -115,7 +115,7 @@ GEM
     bunny (0.9.0.pre10)
       amq-protocol (>= 1.4.0)
     byebug (9.1.0)
-    cancancan (2.0.0)
+    cancancan (2.1.1)
     capybara (2.15.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -217,6 +217,7 @@ GEM
     jwt (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (3.16.14.19)
     libv8 (3.16.14.19-x86_64-darwin-15)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -476,4 +477,4 @@ DEPENDENCIES
   zipkin-tracer
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,6 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
-    libv8 (3.16.14.19-x86_64-darwin-15)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)

--- a/app/models/catalogue.rb
+++ b/app/models/catalogue.rb
@@ -2,6 +2,11 @@ class Catalogue < ApplicationRecord
 
   has_many :products
 
+  before_validation :sanitise_lims
+  before_save :sanitise_lims
+
+  validates :lims_id, presence: true
+
   def self.create_with_products(catalogue_params)
   	catalogue = nil
   	transaction do
@@ -18,5 +23,14 @@ class Catalogue < ApplicationRecord
   		end
   	end
   	catalogue
+  end
+
+  def sanitise_lims
+    if lims_id
+      sanitised = lims_id.strip.gsub(/\s+/,' ')
+      if sanitised != lims_id
+        self.lims_id = sanitised
+      end
+    end
   end
 end

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -7,6 +7,9 @@ class WorkOrder < ApplicationRecord
 
   belongs_to :product, optional: true
 
+  before_validation :sanitise_owner
+  before_save :sanitise_owner
+
   after_initialize :create_uuid
   after_create :set_default_permission_email
 
@@ -75,6 +78,15 @@ class WorkOrder < ApplicationRecord
 
   def broken!
     update_attributes(status: WorkOrder.BROKEN)
+  end
+
+  def sanitise_owner
+    if owner_email
+      sanitised = owner_email.strip.downcase
+      if sanitised != owner_email
+        self.owner_email = sanitised
+      end
+    end
   end
 
   def proposal

--- a/db/migrate/20171113094502_change_columns_to_case_insensitive.rb
+++ b/db/migrate/20171113094502_change_columns_to_case_insensitive.rb
@@ -1,0 +1,18 @@
+class ChangeColumnsToCaseInsensitive < ActiveRecord::Migration[5.0]
+  def up
+    enable_extension 'citext'
+    change_column :catalogues, :lims_id, :citext, null: false
+    change_column :permissions, :permitted, :citext
+    change_column :work_orders, :owner_email, :citext
+
+    Catalogue.find_each { |c| c.save! if c.sanitise_lims }
+    AkerPermissionGem::Permission.find_each { |p| p.save! if p.sanitise_permitted }
+    WorkOrder.where.not(owner_email: nil).find_each { |wo| wo.save! if wo.sanitise_owner }
+  end
+
+  def down
+    change_column :catalogues, :lims_id, :string, null: true
+    change_column :permissions, :permitted, :string
+    change_column :work_orders, :owner_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026124133) do
+ActiveRecord::Schema.define(version: 20171113094502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "citext"
 
   create_table "catalogues", force: :cascade do |t|
     t.string   "url"
-    t.string   "lims_id"
+    t.citext   "lims_id",    null: false
     t.string   "pipeline"
     t.boolean  "current"
     t.datetime "created_at", null: false
@@ -26,7 +27,7 @@ ActiveRecord::Schema.define(version: 20171026124133) do
   end
 
   create_table "permissions", force: :cascade do |t|
-    t.string   "permitted",       null: false
+    t.citext   "permitted",       null: false
     t.string   "accessible_type", null: false
     t.integer  "accessible_id",   null: false
     t.datetime "created_at",      null: false
@@ -66,7 +67,7 @@ ActiveRecord::Schema.define(version: 20171026124133) do
     t.string   "finished_set_uuid"
     t.string   "work_order_uuid"
     t.string   "close_comment"
-    t.string   "owner_email"
+    t.citext   "owner_email"
     t.decimal  "cost_per_sample",   precision: 8, scale: 2
     t.boolean  "material_updated",                          default: false, null: false
     t.index ["owner_email"], name: "index_work_orders_on_owner_email", using: :btree

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -239,7 +239,7 @@ Given(/^a LIMS named "([^"]*)" at url "([^"]*)" has the following catalogue read
       'Material Type' => 'requested_biomaterial_type', 'TAT' => 'TAT', 'Product Class' => 'product_class'}
     products.push(product.keys.reduce({}) {|memo, key| memo[mapping[key]] = product[key] ; memo })
   end
-  @catalogues[lims_name] = {catalogue: {products: products, url: lims_url}}
+  @catalogues[lims_name] = {catalogue: {products: products, url: lims_url, lims_id: lims_name }}
 end
 
 #When(/^all the products of the catalogue are valid products for the billing service$/) do

--- a/spec/factories/catalogues.rb
+++ b/spec/factories/catalogues.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :catalogue do
-    
+    lims_id 'my lims'
   end
 
   factory :catalogue_json, class: Hash do |catalogue|

--- a/spec/models/catalogue_spec.rb
+++ b/spec/models/catalogue_spec.rb
@@ -34,4 +34,23 @@ RSpec.describe Catalogue, type: :model do
     end
 
   end
+
+  describe '#lims_id' do
+    it 'should be sanitised' do
+      expect(create(:catalogue, lims_id: "    My  \t  LIMS  \n").lims_id).to eq('My LIMS')
+    end
+  end
+
+  describe 'validation' do
+    it 'should not be valid without a lims_id' do
+      expect(build(:catalogue, lims_id: nil)).not_to be_valid
+    end
+    it 'should not be valid with a blank lims_id after sanitisation' do
+      expect(build(:catalogue, lims_id: "   \n  \t    ")).not_to be_valid
+    end
+    it 'should be valid with a lims_id after sanitisation' do
+      expect(build(:catalogue, lims_id: "    My  \t  LIMS  \n")).to be_valid
+    end
+  end
+
 end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe AkerPermissionGem::Permission, type: :model do
+  let(:work_order) { create(:work_order) }
+
+  describe '#permitted' do
+    it 'should be sanitised' do
+      expect(described_class.create(accessible: work_order, permitted: '   ALPHA@BETA  ', permission_type: :write).permitted).to eq('alpha@beta')
+    end
+  end
+end

--- a/spec/models/work_order_spec.rb
+++ b/spec/models/work_order_spec.rb
@@ -223,6 +223,12 @@ RSpec.describe WorkOrder, type: :model do
     end
   end
 
+  describe '#owner_email' do
+    it 'should be sanitised' do
+      expect(create(:work_order, owner_email: '    ALPHA@BETA   ').owner_email).to eq('alpha@beta')
+    end
+  end
+
   describe "#lims_data" do
 
     def make_container(materials)
@@ -390,6 +396,18 @@ RSpec.describe WorkOrder, type: :model do
         expect(EventService).to receive(:publish).with(an_instance_of(EventMessage))
         wo.generate_submitted_event
       end
+    end
+  end
+
+  describe '#validation' do
+    it 'should be invalid with no owner_email' do
+      expect(build(:work_order, owner_email: nil)).to be_invalid
+    end
+    it 'should be invalid with an empty owner_email after sanitisation' do
+      expect(build(:work_order, owner_email: "   \n   \t   ")).to be_invalid
+    end
+    it 'should be valid with a non-empty owner_email after sanitisation' do
+      expect(build(:work_order, owner_email: "    ALPHA@BETA   ")).to be_valid
     end
   end
 end


### PR DESCRIPTION
Sanitisation:
* Catalogue.lims_id - strip and contract whitespace. Also added validation.
* WorkOrder.owner_id - strip and downcase
* Permission.permitted - use sanitise_permitted method as defined in
  aker_permission_gem 0.4.1

Also, unit tests.

Other string columns _could_ be converted to citext, but they are
not indexed, not unique, and have no clear use case for case insensitivity.
Such columns include:
* Catalogue.pipeline
* Product.name
* WorkOrder.status