### PR TITLE
a188 - send project uuid and project name in lims_data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,9 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-study-client.git
-  revision: 46f00717d5c68f9dcd70e8407dd9b1712bb7ebc9
+  revision: 1ae82548bcdb1c1d1ca84cf46e3bbf405b7299de
   specs:
-    aker-study-client (0.2.1)
+    aker-study-client (0.2.2)
 
 GIT
   remote: https://github.com/sanger/bootstrap-sass.git

--- a/app/models/work_order.rb
+++ b/app/models/work_order.rb
@@ -184,6 +184,12 @@ class WorkOrder < ApplicationRecord
     end
     describe_containers(material_ids, material_data)
 
+    if proposal.subproject?
+      project = StudyClient::Node.find(proposal.parent_id).first
+    else
+      project = proposal
+    end
+
     {
       work_order: {
         product_name: product.name,
@@ -191,8 +197,8 @@ class WorkOrder < ApplicationRecord
         product_uuid: product.product_uuid,
         work_order_id: id,
         comment: comment,
-        proposal_id: proposal_id,
-        proposal_name: proposal.name,
+        project_uuid: project.node_uuid,
+        project_name: project.name,
         cost_code: proposal.cost_code,
         desired_date: desired_date,
         materials: material_data,

--- a/spec/integration/work_orders_spec.rb
+++ b/spec/integration/work_orders_spec.rb
@@ -18,7 +18,8 @@ describe 'Work Orders API' do
   let(:catalogue) { create(:catalogue) }
   let(:product) { create(:product, catalogue: catalogue) }
 
-  let(:proposal) { made_up_proposal }
+  let(:project) { make_node('my project', 'S0001', 1, 0, false, true) }
+  let(:proposal) { make_node('my proposal', 'S0001-0', 2, project.id, true, false) }
 
   let(:instance_wo) do
     create(:work_order, status: WorkOrder.ACTIVE,

--- a/spec/lib/event_publisher_spec.rb
+++ b/spec/lib/event_publisher_spec.rb
@@ -26,8 +26,11 @@ RSpec.describe 'EventPublisher' do
     @queue = double('queue')
 
     allow(bunny).to receive(:new).with(
-      "amqp://#{params[:broker_username]}:#{params[:broker_password]}"\
-      "@#{params[:broker_host]}:#{params[:broker_port]}",
+      host: params[:broker_host],
+      port: params[:broker_port],
+      vhost: params[:broker_vhost],
+      user: params[:broker_username],
+      pass: params[:broker_password],
       threaded: false
     ).and_return(@connection)
     allow(@connection).to receive(:start)

--- a/spec/support/test_services_helper.rb
+++ b/spec/support/test_services_helper.rb
@@ -104,12 +104,10 @@ module TestServicesHelper
     container
   end
 
-  def made_up_proposal
-    prop = double('proposal', name: 'a name', cost_code: 'a cost code', id: 1)
-
-    allow(StudyClient::Node).to receive(:find).with(prop.id).and_return([prop])
-
-    prop
+  def make_node(name, cost_code, id, parent_id, is_sub, is_proj)
+    n = double('node', name: name, cost_code: cost_code, id: id, parent_id: parent_id, subproject?: is_sub, project?: is_proj, node_uuid: SecureRandom.uuid)
+    allow(StudyClient::Node).to receive(:find).with(n.id).and_return([n])
+    return n
   end
 
   def stub_matcon


### PR DESCRIPTION
Depends on the study service exposing the node parent-id.
That is in a study service pull request.
If the "proposal" is a subproject, look up the parent using StudyClient.
Send "project_uuid" and "project_name" instead of
"proposal_id" and "proposal_name".