### PR TITLE
Move rswag gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'json-schema'
 # Pure Ruby LDAP library. Read more: https://github.com/ruby-ldap/ruby-net-ldap
 gem 'net-ldap'
 gem 'pg', '< 1.0' # https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start
+gem 'pry'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
@@ -81,7 +82,6 @@ end
 
 # Test group
 group :test do
-  gem 'pry'
   gem 'rspec-json_expectations'
   gem 'rubycritic'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Force git gems to use secure HTTPS
@@ -28,7 +30,8 @@ gem 'pg', '< 1.0' # https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-ming
 gem 'puma', '~> 3.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
-gem 'rswag'
+gem 'rswag-api'
+gem 'rswag-ui'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 gem 'swagger-ui_rails'
@@ -81,6 +84,7 @@ group :test do
   gem 'pry'
   gem 'rspec-json_expectations'
   gem 'rubycritic'
+
   # Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of
   # coverage across test suites - https://github.com/colszowka/simplecov
   gem 'simplecov', require: false
@@ -92,6 +96,7 @@ end
 
 # Development and test groups
 group :development, :test do
+  gem 'brakeman', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   gem 'capybara'
@@ -101,10 +106,10 @@ group :development, :test do
   gem 'launchy'
   gem 'poltergeist'
   gem 'rspec-rails', '~> 3.4'
+  gem 'rswag-specs'
   # A Ruby static code analyzer, based on the community Ruby style guide. http://rubocop.readthedocs.io
   gem 'rubocop', '~> 0.51.0', require: false
   gem 'selenium-webdriver'
   gem 'sqlite3'
   gem 'webmock'
-  gem 'brakeman', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,10 +308,6 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rswag (1.5.2)
-      rswag-api (= 1.5.2)
-      rswag-specs (= 1.5.2)
-      rswag-ui (= 1.5.2)
     rswag-api (1.5.2)
       railties (>= 3.1, < 6.0)
     rswag-specs (1.5.2)
@@ -465,7 +461,9 @@ DEPENDENCIES
   rails (~> 5.0.0, >= 5.0.0.1)
   rspec-json_expectations
   rspec-rails (~> 3.4)
-  rswag
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop (~> 0.51.0)
   rubycritic
   sass-rails (~> 5.0)


### PR DESCRIPTION
When installing gems using rvm in ansible we should not install the development, test and deployment gem groups.